### PR TITLE
Warning not to remove the copy stage

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -60,9 +60,11 @@ small = (
     | InjectAttrs()
     | ConsolidateDimensionCoordinates()
     | ConsolidateMetadata()
-    | Copy(target=catalog_store_urls["small"]) # DO NOT REMOVE THIS STAGE. This stage will copy the 
-                                               # resulting zarr array to the location specified in the
-                                               # `catalog.yaml` file. 
+    | Copy(
+        target=catalog_store_urls["small"]
+    )  # DO NOT REMOVE THIS STAGE. This stage will copy the
+    # resulting zarr array to the location specified in the
+    # `catalog.yaml` file.
 )
 
 # larger recipe

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -60,7 +60,9 @@ small = (
     | InjectAttrs()
     | ConsolidateDimensionCoordinates()
     | ConsolidateMetadata()
-    | Copy(target=catalog_store_urls["small"])
+    | Copy(target=catalog_store_urls["small"]) # DO NOT REMOVE THIS STAGE. This stage will copy the 
+                                               # resulting zarr array to the location specified in the
+                                               # `catalog.yaml` file. 
 )
 
 # larger recipe


### PR DESCRIPTION
We need a good way to warn users if the Copy stage is missing (because the data will always just stay in a scratch bucket), as it happened in https://github.com/leap-stc/eNATL_feedstock/pull/9. 

I added a comment here, but there are probably more effective ways to document/enforce this. Leaving this as a WIP for folks to comment.